### PR TITLE
Add matrix answers

### DIFF
--- a/app/controllers/concerns/questionnaire_examples.rb
+++ b/app/controllers/concerns/questionnaire_examples.rb
@@ -28,7 +28,7 @@ module QuestionnaireExamples
   [title] title of the questionnaire (translated where available)
   [language] current language (given as ISO code)
   [languages] all available languages (given as array of ISO codes)
-  [status] one of 'Active' or 'Closed'
+  [status] one of 'Active', 'Inactive' or 'Closed'
   [activated_on] date when questionnaire was activated
   [questionnaire_date] date set by administrator
   [respondents] array of respondents and the completion status

--- a/app/models/concerns/with_language.rb
+++ b/app/models/concerns/with_language.rb
@@ -7,7 +7,7 @@ module WithLanguage
     scope :with_language, -> (language) {
       if language
         where(
-          "languages @> ARRAY[:language] AND language = :language
+          "languages @> ARRAY[:language] AND #{self.table_name}.language = :language
           OR NOT languages @> ARRAY[:language] AND is_default_language",
           language: language
         )

--- a/app/models/questionnaire.rb
+++ b/app/models/questionnaire.rb
@@ -8,7 +8,6 @@ class Questionnaire < ActiveRecord::Base
   has_many :questions
 
   default_scope {
-    includes(:respondents).references(:respondents).
-      where(status: ['Active', 'Closed'])
+    includes(:respondents).references(:respondents)
   }
 end

--- a/app/representers/answer_representer.rb
+++ b/app/representers/answer_representer.rb
@@ -11,4 +11,5 @@ class AnswerRepresenter < Roar::Decorator
   property :user_id
   property :answer_text
   property :details_text
+  property :matrix_answer
 end


### PR DESCRIPTION
## Description

* Fetches matrix_answer property within API endpoint.
  - This works alongside the matrix answers related PR made on the ORS repo

* Allow to fetch data from all questionnaires (so including the `Inactive/Stopped` ones)